### PR TITLE
ユーザの名前が長いときにきづき一覧が崩れる

### DIFF
--- a/app/views/notices/_detail.html.erb
+++ b/app/views/notices/_detail.html.erb
@@ -1,8 +1,10 @@
 <div class="media">
-  <%= link_to user_path(notice.user), class: "pull-left" do %>
-    <%= image_tag notice.user.icon_url, alt: notice.user.nickname, class: "img-rounded", size: "64x64" %>
-    <br><%= notice.user.nickname %>
-  <% end %>
+  <div class="col-md-1 pull-left">
+    <%= link_to user_path(notice.user) do %>
+      <%= image_tag notice.user.icon_url, alt: notice.user.nickname, class: "img-rounded", size: "64x64" %>
+      <br><small><%= notice.user.nickname %></small>
+    <% end %>
+  </div>
   <div class="media-body">
     <div class="panel panel-default">
       <div class="panel-heading">


### PR DESCRIPTION
refs #74
ユーザ画像と名前のまわりにdivをかぶせた
