### PR TITLE
Fix solr test port

### DIFF
--- a/config/sunspot.yml
+++ b/config/sunspot.yml
@@ -17,7 +17,6 @@ development:
 test:
   solr:
     hostname: localhost
-    port: 8981
+    port: 8982
     log_level: WARNING
     path: /solr/test
-    


### PR DESCRIPTION
開発機のmacでsolrの起動ポートがテストのときも 8982になってたので、修正。